### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,3 +177,8 @@ ngrok http 8080
 ```
 
 Then set the `CALLBACK_SERVER_URL` to the ngrok URL.
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/khan2a-telephony-mcp-server).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/khan2a-telephony-mcp-server).